### PR TITLE
Fix: Set base path for GitHub Pages deployment

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/Connector/',
   plugins: [
     react(),
     tsconfigPaths()


### PR DESCRIPTION
This PR fixes the GitHub Pages deployment by setting the correct base path in Vite configuration to accommodate the repository name in the URL path (https://standora.github.io/Connector/).